### PR TITLE
Ensure both writers write/flush together

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -35,11 +35,13 @@ impl<L, R> TeeWriter<L, R> {
 impl<L: Write, R: Write> Write for TeeWriter<L, R> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         let n = self.write.write(buf)?;
-        let _ = self.output.write(&buf[..n])?;
+        self.output.write_all(&buf[..n])?;
         Ok(n)
     }
 
     fn flush(&mut self) -> Result<()> {
-        self.write.flush()
+        let x = self.write.flush();
+        let y = self.output.flush();
+        x.and(y)
     }
 }


### PR DESCRIPTION
`TeeWriter::write` can potentially write different amounts of bytes to both writers. I've added a `write_all` on the 2nd write that ensures `TeeWriter::write` will only return `Ok(n)` only if *both* underlying writers have written exactly `n` bytes. It is a naïve fix and probably not optimal, but it does the job.

Additionally, `TeeWriter::flush` only flushes one of the underlying writers, so I've added a 2nd flush and ensure it returns `Ok(())` only if *both* underlying writers have successfully flushed their buffers.